### PR TITLE
Add dark theme toggle and fix lingering nodes on sidebar

### DIFF
--- a/locales/en/menu.ftl
+++ b/locales/en/menu.ftl
@@ -12,5 +12,6 @@ export-code = { -export-code-btn(label: "Generate Code") }
 export-pdf = { -export-pdf-btn(label: "Plot to PDF") }
 
 language = { -language-btn(label: "Language") }
+dark-theme = Dark Theme
 
 parameter-estimation = { -parameter-estimation-btn(label: "Parameter Estimation") }

--- a/locales/pt/menu.ftl
+++ b/locales/pt/menu.ftl
@@ -12,5 +12,6 @@ export-code = { -export-code-btn(label: "Gerar Código") }
 export-pdf = { -export-pdf-btn(label: "Plotar em PDF") }
 
 language = { -language-btn(label: "Idioma") }
+dark-theme = Tema escuro
 
 parameter-estimation = { -parameter-estimation-btn(label: "Estimativa de Parâmetros") }

--- a/src/core/app.rs
+++ b/src/core/app.rs
@@ -131,6 +131,33 @@ impl SimulationState {
             flags.set(imgui::TabItemFlags::SET_SELECTED, true);
         }
 
+        let bg_color = if self.plot.bg_color {
+            (0.5, 0.5, 0.5, 1.0)
+        } else {
+            (1.0, 1.0, 1.0, 1.0)
+        };
+        let _bg_color_token = implot::push_style_color(
+            &implot::PlotColorElement::PlotBg,
+            bg_color.0,
+            bg_color.1,
+            bg_color.2,
+            bg_color.3,
+        );
+        let _plot_border_color = implot::push_style_color(
+            &implot::PlotColorElement::FrameBg,
+            bg_color.0,
+            bg_color.1,
+            bg_color.2,
+            bg_color.3,
+        );
+        let _legend_border_color = implot::push_style_color(
+            &implot::PlotColorElement::LegendBackground,
+            bg_color.0,
+            bg_color.1,
+            bg_color.2,
+            bg_color.3,
+        );
+
         imgui::TabItem::new(locale.get("tab-all-plots"))
             .opened(&mut opened)
             .flags(flags)
@@ -234,6 +261,10 @@ impl SimulationState {
                 });
         }
 
+        _bg_color_token.pop();
+        _plot_border_color.pop();
+        _legend_border_color.pop();
+
         if opened {
             TabAction::Open
         } else {
@@ -257,6 +288,7 @@ pub struct App {
     pub extensions: Vec<Extension>,
     pub text_fields: TextFields,
     pub parameter_estimation_state: Option<ParameterEstimationState>,
+    pub dark_theme: bool,
 }
 
 pub enum AppState {
@@ -1315,6 +1347,16 @@ impl App {
 
     pub fn clear_state(&mut self) {
         self.nodes.clear();
+
+        let fixed = [
+            "\u{f0ae7} Term",
+            "\u{ebb6} Expression",
+            "\u{f0272} Assigner",
+        ];
+
+        self.node_types
+            .retain(|node_type| fixed.contains(&node_type.name.as_str()));
+
         self.input_pins.clear();
         self.output_pins.clear();
         self.links.clear();

--- a/src/core/menu.rs
+++ b/src/core/menu.rs
@@ -1,4 +1,4 @@
-use imgui::Ui;
+use imgui::{Ui, StyleVar};
 
 use crate::{
     locale::{Locale, LANGUAGES},
@@ -114,6 +114,31 @@ impl App {
             ui.menu(locale.get("run"), || {
                 self.draw_input_label(ui);
 
+                // Toggle dark theme
+
+                ui.separator();
+
+                let text = locale.get("dark-theme");
+                let text_width = ui.calc_text_size(text)[0];
+                let checkbox_size = 16.0; 
+                let spacing = 8.0;
+                let total_width = text_width + spacing + checkbox_size;
+
+                let window_width = ui.content_region_avail()[0];
+                let start_x = (window_width - total_width) / 2.0;
+                ui.set_cursor_pos([start_x, ui.cursor_pos()[1]]);
+
+                ui.text(text);
+                ui.same_line_with_spacing(0.0, spacing);
+
+                let mut dark_theme_toggle = self.dark_theme;
+                let _style = ui.push_style_var(StyleVar::FramePadding([2.0, 2.0]));
+                if ui.checkbox("##dark_theme", &mut dark_theme_toggle) {
+                    self.dark_theme = dark_theme_toggle;
+                }
+
+                ui.separator();
+
                 if ui.menu_item(locale.get("run")) {
                     let py_code = self.generate_code();
 
@@ -137,6 +162,7 @@ impl App {
                                     simulation_state.plot.ylabel =
                                         self.text_fields.y_label.to_string();
                                 }
+                                simulation_state.plot.bg_color = self.dark_theme;
                                 self.simulation_state = Some(simulation_state);
                             }
                         }

--- a/src/core/plot.rs
+++ b/src/core/plot.rs
@@ -15,6 +15,7 @@ pub struct PlotInfo {
     pub xlabel: String,
     pub ylabel: String,
     pub data: CSVData,
+    pub bg_color: bool,
 }
 
 #[derive(Default, Clone)]
@@ -85,6 +86,7 @@ impl PlotInfo {
             title: String::from(""),
             xlabel: locale.get("default-x-label").to_owned(),
             ylabel: locale.get("default-y-label").to_owned(),
+            bg_color: false,
         }
     }
 


### PR DESCRIPTION
- Implemented a toggle to switch the chart between light and dark themes in the Run menu.
- Fixed an issue where previously created nodes would remain on the sidebar after loading a new file.